### PR TITLE
feat: move utils to internal (#27)

### DIFF
--- a/internal/reflect/reflect.go
+++ b/internal/reflect/reflect.go
@@ -1,11 +1,34 @@
-package test
+// Package reflect contains a collection of helpful generic functions helping
+// with reflection. It is currently not part of the public interface and must
+// be consider as highly instable.
+package reflect
 
 import (
 	"reflect"
 	"unsafe"
 )
 
-func extract[P any](param P, deflt any, names ...string) any {
+// Aliases for types.
+type (
+	// Value alias for `reflect.Value`.
+	Value = reflect.Value
+	// Type alias for `reflect.Type`.
+	Type = reflect.Type
+)
+
+// Aliases for functions and values.
+var (
+	// TypeOf alias for `reflect.TypeOf`.
+	TypeOf = reflect.TypeOf
+	// ValueOf alias for `reflect.ValueOf`.
+	ValueOf = reflect.ValueOf
+	// Func alias for `reflect.Func`.
+	Func = reflect.Func
+)
+
+// FindArgOf find the first argument with one of the given field names matching
+// the type matching the default argument type.
+func FindArgOf[P any](param P, deflt any, names ...string) any {
 	t := reflect.TypeOf(param)
 	dt := reflect.TypeOf(deflt)
 	if t.Kind() != reflect.Struct {
@@ -23,11 +46,11 @@ func extract[P any](param P, deflt any, names ...string) any {
 		if fv.Type().Kind() == dt.Kind() {
 			for _, name := range names {
 				if t.Field(i).Name == name {
-					return getReflect(v, i)
+					return FieldArgOf(v, i)
 				}
 			}
 			if !found {
-				deflt = getReflect(v, i)
+				deflt = FieldArgOf(v, i)
 				found = true
 			}
 		}
@@ -35,10 +58,11 @@ func extract[P any](param P, deflt any, names ...string) any {
 	return deflt
 }
 
-func getReflect(v reflect.Value, i int) any {
+// FieldArgOf returns the argument of the `i`th field of the given value.
+func FieldArgOf(v reflect.Value, i int) any {
 	vf := v.Field(i)
 	if vf.CanInterface() {
-		return getValue(vf)
+		return ArgOf(vf)
 	}
 
 	// Make a copy to circumvent access restrictions.
@@ -54,7 +78,8 @@ func getReflect(v reflect.Value, i int) any {
 	return value
 }
 
-func getValue(v reflect.Value) any {
+// ArgOf returns the argument of the given value.
+func ArgOf(v reflect.Value) any {
 	switch v.Type().Kind() {
 	case reflect.Bool:
 		return v.Bool()

--- a/internal/reflect/reflect_test.go
+++ b/internal/reflect/reflect_test.go
@@ -1,14 +1,16 @@
-package test
+package reflect_test
 
 import (
-	reflect "reflect"
 	"testing"
 
+	"github.com/tkrop/go-testing/internal/reflect"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/tkrop/go-testing/test"
 )
 
 var (
-	testchan    = make(chan Test)
+	testchan    = make(chan test.Test)
 	testint     = 1
 	testfloat   = 1.0
 	testcomplex = complex(1.0, 1.0)
@@ -16,14 +18,14 @@ var (
 	testmap     = map[string]string{"value": "value"}
 )
 
-type GetValueParams struct {
+func FuncTest() {}
+
+type ArgOfParams struct {
 	value  reflect.Value
 	expect any
 }
 
-func FuncTest() {}
-
-var testGetValueParams = map[string]GetValueParams{
+var testArgOfParams = map[string]ArgOfParams{
 	"bool": {
 		value:  reflect.ValueOf(true),
 		expect: true,
@@ -115,8 +117,8 @@ var testGetValueParams = map[string]GetValueParams{
 		expect: testmap,
 	},
 	"struct": {
-		value:  reflect.ValueOf(GetValueParams{expect: "value"}),
-		expect: GetValueParams{expect: "value"},
+		value:  reflect.ValueOf(ArgOfParams{expect: "value"}),
+		expect: ArgOfParams{expect: "value"},
 	},
 	"chan": {
 		value:  reflect.ValueOf(testchan),
@@ -128,22 +130,23 @@ var testGetValueParams = map[string]GetValueParams{
 	},
 }
 
-func TestGetValue(t *testing.T) {
-	Map(t, testGetValueParams).Run(func(t Test, param GetValueParams) {
-		// When
-		value := getValue(param.value)
+func TestArgOf(t *testing.T) {
+	test.Map(t, testArgOfParams).
+		Run(func(t test.Test, param ArgOfParams) {
+			// When
+			value := reflect.ArgOf(param.value)
 
-		// Then
-		if param.value.Type().Kind() == reflect.Func {
-			assert.NotNil(t, value)
-			assert.True(t, reflect.TypeOf(value).Kind() == reflect.Func)
-		} else {
-			assert.Equal(t, param.expect, value)
-		}
-	})
+			// Then
+			if param.value.Type().Kind() == reflect.Func {
+				assert.NotNil(t, value)
+				assert.True(t, reflect.TypeOf(value).Kind() == reflect.Func)
+			} else {
+				assert.Equal(t, param.expect, value)
+			}
+		})
 }
 
-type ExtractParams struct {
+type FindArgOfParams struct {
 	name   string
 	value  any
 	deflt  any
@@ -170,7 +173,7 @@ type StructParams struct {
 	value BoolParams
 }
 
-var testExtractParams = map[string]ExtractParams{
+var testFindArgOfParams = map[string]FindArgOfParams{
 	"no struct": {
 		name:   "value",
 		value:  "string",
@@ -309,10 +312,10 @@ var testExtractParams = map[string]ExtractParams{
 	},
 }
 
-func TestExtract(t *testing.T) {
-	Map(t, testExtractParams).Run(func(t Test, param ExtractParams) {
+func TestFindArgOf(t *testing.T) {
+	test.Map(t, testFindArgOfParams).Run(func(t test.Test, param FindArgOfParams) {
 		// When
-		value := extract(param.value, param.deflt, param.name)
+		value := reflect.FindArgOf(param.value, param.deflt, param.name)
 
 		// Then
 		assert.Equal(t, param.expect, value)

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,3 +1,6 @@
+// Package slices contains a collection of helpful generic functions for
+// working with slices. It is currently not part of the public interface and
+// must be consider as highly instable.
 package slices
 
 // Reverse reverses the given slice.

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tkrop/go-testing/utils/slices"
+	"github.com/tkrop/go-testing/internal/slices"
 )
 
 func TestReverse(t *testing.T) {

--- a/perm/perm.go
+++ b/perm/perm.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tkrop/go-testing/internal/slices"
+
 	"github.com/tkrop/go-testing/mock"
 	"github.com/tkrop/go-testing/test"
-	"github.com/tkrop/go-testing/utils/slices"
 )
 
 // ExpectMap defines a map of permutation tests that are expected to either

--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,7 @@ test environment.
 
 ```go
 func TestUnit(t *testing.T) {
-    test.Run(func(t test.Test){
+    test.Run(test.Success, func(t test.Test){
         // Given
         mocks := mock.NewMock(t).Expect(
             test.Panic("fail"),

--- a/test/testing.go
+++ b/test/testing.go
@@ -3,7 +3,6 @@ package test
 import (
 	"fmt"
 	"math"
-	"reflect"
 	"runtime"
 	gosync "sync"
 	"sync/atomic"
@@ -12,9 +11,11 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tkrop/go-testing/internal/reflect"
+	"github.com/tkrop/go-testing/internal/slices"
+
 	"github.com/tkrop/go-testing/mock"
 	"github.com/tkrop/go-testing/sync"
-	"github.com/tkrop/go-testing/utils/slices"
 )
 
 type (
@@ -373,7 +374,7 @@ func (r *runner[P]) wrap(
 
 // name resolves the test case name from the parameter set.
 func (r *runner[P]) name(param P) Name {
-	name, ok := extract(param, unknownName, "name").(Name)
+	name, ok := reflect.FindArgOf(param, unknownName, "name").(Name)
 	if ok && name != "" {
 		return name
 	}
@@ -382,7 +383,7 @@ func (r *runner[P]) name(param P) Name {
 
 // expect resolves the test case expectation from the parameter set.
 func (r *runner[P]) expect(param P) Expect {
-	if expect, ok := extract(param, Success, "expect").(Expect); ok {
+	if expect, ok := reflect.FindArgOf(param, Success, "expect").(Expect); ok {
 		return expect
 	}
 	return Success


### PR DESCRIPTION
This pull request hides the unstable packages in `utils` by moving them to the `internal` folder, also extracting `reflect` methods into an own package. Not sure how `internal` works out on libraries - may be I have to revert later.