### PR TITLE
feat: simplify mock setup (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,6 @@ The `testing` framework consists of the following sub-packages:
   controller and a mock storage that allows to run tests isolated. This allows
   to parallelize simple test and parameterized tests.
 
-* [sync](sync) provides a lenient wait group implementation for coordinating
-  [mock](mock)s in the isolated [test](test)s to gracefully unlock all waiters
-  after test failures to finish the test.
-
 * [perm](perm) provides a small framework to simplify permutation tests, i.e.
   a consistent test set where conditions can be checked in all known orders
   with different outcome. This is very handy in combination with [test](test)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/exp v0.0.0-20221230185412-738e83a70c30
 	golang.org/x/text v0.3.3
 	gopkg.in/h2non/gock.v1 v1.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/exp v0.0.0-20221230185412-738e83a70c30 h1:m9O6OTJ627iFnN2JIWfdqlZCzneRO6EEBsHXI25P8ws=
+golang.org/x/exp v0.0.0-20221230185412-738e83a70c30/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,22 @@
+# Internal utils
+
+The `internal` utils contain the all helpful generic solutions developed to
+support the functionality of the `testing` framework, but are not supposed to
+be exported and used by others.
+
+The `internal` utils consist of the following sub-packages:
+
+*   [math](math) provides generic `Min`/`Max` functions that are used by the
+    [reflect](reflect) package.
+
+*   [reflect](reflect) contains a collection of helpful generic functions that
+    support reflection. The functions are used by the [mock](../mock) and the
+    [test](../test) packages to implement major features.
+
+*   [slices](slices) contains a collection of helpful generic functions for
+    working with slices. The functions are mainly used by the [perm](../perm)
+    and the [test](../test) package to implement minor features.
+
+*   [sync](sync) provides a lenient wait group implementation for coordinating
+    [mock](../mock)s in the isolated [test](../test)s to gracefully unlock all
+    waiters after test failures to finish the test.

--- a/internal/math/math.go
+++ b/internal/math/math.go
@@ -1,0 +1,30 @@
+// Package math contains a collection of helpful generic functions helping with
+// mathematical problems. It is currently not part of the public interface and
+// must be consider as highly instable.
+package math
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+// Max returns the maximal argument of the given arguments.
+func Max[T constraints.Ordered](args ...T) T {
+	max := args[0]
+	for _, arg := range args[1:] {
+		if arg > max {
+			max = arg
+		}
+	}
+	return max
+}
+
+// Min returns the minimal argument of the given arguments.
+func Min[T constraints.Ordered](args ...T) T {
+	min := args[0]
+	for _, arg := range args[1:] {
+		if arg < min {
+			min = arg
+		}
+	}
+	return min
+}

--- a/internal/math/math_test.go
+++ b/internal/math/math_test.go
@@ -1,0 +1,90 @@
+package math_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tkrop/go-testing/internal/math"
+	"github.com/tkrop/go-testing/mock"
+	"github.com/tkrop/go-testing/test"
+)
+
+type MinMaxParams struct {
+	setup  mock.SetupFunc
+	values []int
+	result int
+	expect test.Expect
+}
+
+var testMinParams = map[string]MinMaxParams{
+	"no-values": {
+		setup: test.Panic("runtime error: index out of range [0] with length 0"),
+	},
+
+	"first-value": {
+		values: []int{-2, -1, 0, 1, 2},
+		result: -2,
+		expect: test.Success,
+	},
+	"last-value": {
+		values: []int{2, 1, 0, -1, -2},
+		result: -2,
+		expect: test.Success,
+	},
+	"middle-value": {
+		values: []int{-1, 1, -2, 2, 0},
+		result: -2,
+		expect: test.Success,
+	},
+}
+
+func TestMin(t *testing.T) {
+	test.Map(t, testMinParams).
+		Run(func(t test.Test, param MinMaxParams) {
+			// Given
+			mock.NewMock(t).Expect(param.setup)
+
+			// When
+			result := math.Min(param.values...)
+
+			// Then
+			assert.Equal(t, param.result, result)
+		})
+}
+
+var testMaxParams = map[string]MinMaxParams{
+	"no-values": {
+		setup: test.Panic("runtime error: index out of range [0] with length 0"),
+	},
+
+	"first-value": {
+		values: []int{2, 1, 0, -1, -2},
+		result: 2,
+		expect: test.Success,
+	},
+	"last-value": {
+		values: []int{-2, -1, 0, 1, 2},
+		result: 2,
+		expect: test.Success,
+	},
+	"middle-value": {
+		values: []int{-1, 1, -2, 2, 0},
+		result: 2,
+		expect: test.Success,
+	},
+}
+
+func TestMax(t *testing.T) {
+	test.Map(t, testMaxParams).
+		Run(func(t test.Test, param MinMaxParams) {
+			// Given
+			mock.NewMock(t).Expect(param.setup)
+
+			// When
+			result := math.Max(param.values...)
+
+			// Then
+			assert.Equal(t, param.result, result)
+		})
+}

--- a/internal/reflect/reflect.go
+++ b/internal/reflect/reflect.go
@@ -1,11 +1,14 @@
-// Package reflect contains a collection of helpful generic functions helping
-// with reflection. It is currently not part of the public interface and must
-// be consider as highly instable.
+// Package reflect contains a collection of helpful generic functions that
+// support reflection. It is currently not part of the public interface and
+// must be consider as highly instable.
 package reflect
 
 import (
+	"fmt"
 	"reflect"
 	"unsafe"
+
+	"github.com/tkrop/go-testing/internal/math"
 )
 
 // Aliases for types.
@@ -16,14 +19,18 @@ type (
 	Type = reflect.Type
 )
 
-// Aliases for functions and values.
+// Aliases for constant values.
+const (
+	// Func alias for `reflect.Func`.
+	Func = reflect.Func
+)
+
+// Aliases for function values.
 var (
 	// TypeOf alias for `reflect.TypeOf`.
 	TypeOf = reflect.TypeOf
 	// ValueOf alias for `reflect.ValueOf`.
 	ValueOf = reflect.ValueOf
-	// Func alias for `reflect.Func`.
-	Func = reflect.Func
 )
 
 // FindArgOf find the first argument with one of the given field names matching
@@ -80,6 +87,10 @@ func FieldArgOf(v reflect.Value, i int) any {
 
 // ArgOf returns the argument of the given value.
 func ArgOf(v reflect.Value) any {
+	if !v.IsValid() {
+		return nil
+	}
+
 	switch v.Type().Kind() {
 	case reflect.Bool:
 		return v.Bool()
@@ -119,4 +130,145 @@ func ArgOf(v reflect.Value) any {
 	default:
 		return v.Interface()
 	}
+}
+
+// ArgsOf returns the arguents slice for the given values.
+func ArgsOf(values ...reflect.Value) []any {
+	args := make([]any, 0, len(values))
+	for _, value := range values {
+		args = append(args, ArgOf(value))
+	}
+
+	if len(args) == 0 {
+		return nil
+	}
+	return args
+}
+
+// ValuesIn returns the reflection values matching the input arguments of the
+// given function.
+func ValuesIn(ftype reflect.Type, args ...any) []reflect.Value {
+	return valuesOf(typesIn(ftype, len(args)), args...)
+}
+
+// ValuesOut returns the reflection values matching the output arguments of
+// the given function.
+func ValuesOut(ftype reflect.Type, args ...any) []reflect.Value {
+	return valuesOf(typesOut(ftype, len(args)), args...)
+}
+
+// valuesOf returns the reflection valuesOf for the given arguments. The types must
+// be provided via `typesOf` that extends a variadic type function to infinity by
+// returning the variadic base element on all followup indexes.
+func valuesOf(ftype func(i int) reflect.Type, args ...any) []reflect.Value {
+	vs := make([]reflect.Value, 0, len(args))
+	for i, arg := range args {
+		t := ftype(i)
+		if arg == nil {
+			vs = append(vs, reflect.New(t).Elem())
+		} else {
+			v := reflect.ValueOf(arg)
+			if !v.Type().AssignableTo(t) {
+				panic(ErrInvalidType(i, t, v.Type()))
+			}
+			vs = append(vs, reflect.ValueOf(arg))
+		}
+	}
+
+	if len(vs) == 0 {
+		return nil
+	}
+	return vs
+}
+
+// ErrInvalidType creates a new error reporting an invalid type during value
+// slice creation.
+func ErrInvalidType(index int, expect, actual reflect.Type) error {
+	return fmt.Errorf("invalid type at %d: expect %v got %v",
+		index, expect, actual)
+}
+
+// typesOf checks the arguments length and provides the matching input type
+// function from the function type. The type function is a wrapper that returns
+// a variadic base type inifinitely.
+func typesIn(ftype reflect.Type, args int) func(int) reflect.Type {
+	num := ftype.NumIn()
+	variadic := ftype.IsVariadic()
+	if variadic {
+		num--
+	}
+
+	if args < num {
+		panic("not enough arguments")
+	} else if !variadic {
+		if args > num {
+			panic("too many arguments")
+		}
+		return ftype.In
+	}
+
+	t := ftype.In(num).Elem()
+	return func(i int) reflect.Type {
+		if i < num {
+			return ftype.In(i)
+		}
+		return t
+	}
+}
+
+// typesOut the arguments length and provides an output type function.
+func typesOut(ftype reflect.Type, args int) func(int) reflect.Type {
+	num := ftype.NumOut()
+	if args < num {
+		panic("not enough arguments")
+	} else if args > num {
+		panic("too many arguments")
+	}
+	return ftype.Out
+}
+
+// AnyFuncOf returns a function with given number of arguments accepting any
+// type.
+func AnyFuncOf(args int, variadic bool) reflect.Type {
+	ite := reflect.TypeOf((*any)(nil)).Elem()
+
+	it := make([]reflect.Type, 0, args)
+	for i := 0; i < args; i++ {
+		if i == args-1 && variadic {
+			it = append(it, reflect.TypeOf([]any{}))
+		} else {
+			it = append(it, ite)
+		}
+	}
+
+	return reflect.FuncOf(it, []reflect.Type{}, variadic)
+}
+
+// BaseFuncOf allows to extract a base function from an interface function
+// containing no receiver and suppressing the return values - if necessary. The
+// given `in` and `out` values allow to restrict the included input and output
+// arguments. Use `1` to remove the first argument, or `NumIn/NumOut` to remove
+// all arguments.
+func BaseFuncOf(mtype reflect.Type, in, out int) reflect.Type {
+	it := make([]reflect.Type, 0, math.Max(mtype.NumIn()-in, 0))
+	for i := in; i < mtype.NumIn(); i++ {
+		it = append(it, mtype.In(i))
+	}
+
+	ot := make([]reflect.Type, 0, math.Max(mtype.NumOut()-out, 0))
+	for i := out; i < mtype.NumOut(); i++ {
+		ot = append(ot, mtype.Out(i))
+	}
+
+	return reflect.FuncOf(it, ot, mtype.IsVariadic())
+}
+
+// MakeFuncOf returns a newly created function with given reflective function.
+func MakeFuncOf(
+	mtype reflect.Type, call func([]reflect.Value) []reflect.Value,
+) any {
+	mvalue := reflect.New(mtype).Elem()
+	mvalue.Set(reflect.MakeFunc(mtype, call))
+
+	return mvalue.Interface()
 }

--- a/internal/reflect/reflect_test.go
+++ b/internal/reflect/reflect_test.go
@@ -1,11 +1,14 @@
 package reflect_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/tkrop/go-testing/internal/reflect"
+	"github.com/tkrop/go-testing/mock"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tkrop/go-testing/test"
 )
 
@@ -16,135 +19,12 @@ var (
 	testcomplex = complex(1.0, 1.0)
 	teststring  = "value"
 	testmap     = map[string]string{"value": "value"}
+	teststruct  = ExportParams{Value: "value"}
+	testarray   = [1]string{"value"}
+	testslice   = []string{"value"}
 )
 
 func FuncTest() {}
-
-type ArgOfParams struct {
-	value  reflect.Value
-	expect any
-}
-
-var testArgOfParams = map[string]ArgOfParams{
-	"bool": {
-		value:  reflect.ValueOf(true),
-		expect: true,
-	},
-	"int": {
-		value:  reflect.ValueOf(int(1)),
-		expect: int(1),
-	},
-	"int8": {
-		value:  reflect.ValueOf(int8(1)),
-		expect: int8(1),
-	},
-	"int16": {
-		value:  reflect.ValueOf(int16(1)),
-		expect: int16(1),
-	},
-	"int32": {
-		value:  reflect.ValueOf(int32(1)),
-		expect: int32(1),
-	},
-	"int64": {
-		value:  reflect.ValueOf(int64(1)),
-		expect: int64(1),
-	},
-	"intptr": {
-		value:  reflect.ValueOf(&testint),
-		expect: &testint,
-	},
-	"uint": {
-		value:  reflect.ValueOf(uint(1)),
-		expect: uint(1),
-	},
-	"uint8": {
-		value:  reflect.ValueOf(uint8(1)),
-		expect: uint8(1),
-	},
-	"uint16": {
-		value:  reflect.ValueOf(uint16(1)),
-		expect: uint16(1),
-	},
-	"uint32": {
-		value:  reflect.ValueOf(uint32(1)),
-		expect: uint32(1),
-	},
-	"uint64": {
-		value:  reflect.ValueOf(uint64(1)),
-		expect: uint64(1),
-	},
-
-	"float32": {
-		value:  reflect.ValueOf(float32(1)),
-		expect: float32(1),
-	},
-	"float64": {
-		value:  reflect.ValueOf(float64(1)),
-		expect: float64(1),
-	},
-	"floatptr": {
-		value:  reflect.ValueOf(&testfloat),
-		expect: &testfloat,
-	},
-	"complex64": {
-		value:  reflect.ValueOf(complex64(testcomplex)),
-		expect: complex64(testcomplex),
-	},
-	"complex128": {
-		value:  reflect.ValueOf(testcomplex),
-		expect: testcomplex,
-	},
-	"string": {
-		value:  reflect.ValueOf("value"),
-		expect: "value",
-	},
-	"stringptr": {
-		value:  reflect.ValueOf(&teststring),
-		expect: &teststring,
-	},
-
-	"array": {
-		value:  reflect.ValueOf([1]string{"value"}),
-		expect: [1]string{"value"},
-	},
-	"slice": {
-		value:  reflect.ValueOf([]string{"value"}),
-		expect: []string{"value"},
-	},
-	"map": {
-		value:  reflect.ValueOf(testmap),
-		expect: testmap,
-	},
-	"struct": {
-		value:  reflect.ValueOf(ArgOfParams{expect: "value"}),
-		expect: ArgOfParams{expect: "value"},
-	},
-	"chan": {
-		value:  reflect.ValueOf(testchan),
-		expect: testchan,
-	},
-	"func": {
-		value:  reflect.ValueOf(FuncTest),
-		expect: FuncTest,
-	},
-}
-
-func TestArgOf(t *testing.T) {
-	test.Map(t, testArgOfParams).
-		Run(func(t test.Test, param ArgOfParams) {
-			// When
-			value := reflect.ArgOf(param.value)
-
-			// Then
-			if param.value.Type().Kind() == reflect.Func {
-				assert.NotNil(t, value)
-				assert.True(t, reflect.TypeOf(value).Kind() == reflect.Func)
-			} else {
-				assert.Equal(t, param.expect, value)
-			}
-		})
-}
 
 type FindArgOfParams struct {
 	name   string
@@ -313,11 +193,588 @@ var testFindArgOfParams = map[string]FindArgOfParams{
 }
 
 func TestFindArgOf(t *testing.T) {
-	test.Map(t, testFindArgOfParams).Run(func(t test.Test, param FindArgOfParams) {
-		// When
-		value := reflect.FindArgOf(param.value, param.deflt, param.name)
+	test.Map(t, testFindArgOfParams).
+		Run(func(t test.Test, param FindArgOfParams) {
+			// When
+			value := reflect.FindArgOf(param.value, param.deflt, param.name)
 
-		// Then
-		assert.Equal(t, param.expect, value)
-	})
+			// Then
+			assert.Equal(t, param.expect, value)
+		})
+}
+
+type ArgOfParams struct {
+	value  reflect.Value
+	expect any
+}
+
+var testArgOfParams = map[string]ArgOfParams{
+	"nil": {
+		value:  reflect.ValueOf(nil),
+		expect: nil,
+	},
+
+	"bool": {
+		value:  reflect.ValueOf(true),
+		expect: true,
+	},
+	"int": {
+		value:  reflect.ValueOf(int(1)),
+		expect: int(1),
+	},
+	"int8": {
+		value:  reflect.ValueOf(int8(1)),
+		expect: int8(1),
+	},
+	"int16": {
+		value:  reflect.ValueOf(int16(1)),
+		expect: int16(1),
+	},
+	"int32": {
+		value:  reflect.ValueOf(int32(1)),
+		expect: int32(1),
+	},
+	"int64": {
+		value:  reflect.ValueOf(int64(1)),
+		expect: int64(1),
+	},
+	"intptr": {
+		value:  reflect.ValueOf(&testint),
+		expect: &testint,
+	},
+	"uint": {
+		value:  reflect.ValueOf(uint(1)),
+		expect: uint(1),
+	},
+	"uint8": {
+		value:  reflect.ValueOf(uint8(1)),
+		expect: uint8(1),
+	},
+	"uint16": {
+		value:  reflect.ValueOf(uint16(1)),
+		expect: uint16(1),
+	},
+	"uint32": {
+		value:  reflect.ValueOf(uint32(1)),
+		expect: uint32(1),
+	},
+	"uint64": {
+		value:  reflect.ValueOf(uint64(1)),
+		expect: uint64(1),
+	},
+
+	"float32": {
+		value:  reflect.ValueOf(float32(1)),
+		expect: float32(1),
+	},
+	"float64": {
+		value:  reflect.ValueOf(float64(1)),
+		expect: float64(1),
+	},
+	"floatptr": {
+		value:  reflect.ValueOf(&testfloat),
+		expect: &testfloat,
+	},
+	"complex64": {
+		value:  reflect.ValueOf(complex64(testcomplex)),
+		expect: complex64(testcomplex),
+	},
+	"complex128": {
+		value:  reflect.ValueOf(testcomplex),
+		expect: testcomplex,
+	},
+	"string": {
+		value:  reflect.ValueOf("value"),
+		expect: "value",
+	},
+	"stringptr": {
+		value:  reflect.ValueOf(&teststring),
+		expect: &teststring,
+	},
+
+	"array": {
+		value:  reflect.ValueOf(testarray),
+		expect: testarray,
+	},
+	"slice": {
+		value:  reflect.ValueOf(testslice),
+		expect: testslice,
+	},
+	"map": {
+		value:  reflect.ValueOf(testmap),
+		expect: testmap,
+	},
+	"struct": {
+		value:  reflect.ValueOf(teststruct),
+		expect: teststruct,
+	},
+	"chan": {
+		value:  reflect.ValueOf(testchan),
+		expect: testchan,
+	},
+	"func": {
+		value:  reflect.ValueOf(FuncTest),
+		expect: FuncTest,
+	},
+}
+
+func TestArgOf(t *testing.T) {
+	test.Map(t, testArgOfParams).
+		Run(func(t test.Test, param ArgOfParams) {
+			// When
+			arg := reflect.ArgOf(param.value)
+
+			// Then
+			if !param.value.IsValid() {
+				assert.Equal(t, param.expect, arg)
+			} else if param.value.Type().Kind() == reflect.Func {
+				assert.NotNil(t, arg)
+				assert.True(t, reflect.TypeOf(arg).Kind() == reflect.Func)
+			} else {
+				assert.Equal(t, param.expect, arg)
+			}
+		})
+}
+
+type ArgsOfParams struct {
+	values []reflect.Value
+	args   []any
+}
+
+var testArgsOfParams = map[string]ArgsOfParams{
+	"values-nil": {
+		values: nil,
+		args:   nil,
+	},
+	"values-empty": {
+		values: []reflect.Value{},
+		args:   nil,
+	},
+
+	"nil": {
+		values: []reflect.Value{
+			reflect.ValueOf(nil), reflect.ValueOf(nil),
+		},
+		args: []any{nil, nil},
+	},
+
+	"bool": {
+		values: []reflect.Value{
+			reflect.ValueOf(true), reflect.ValueOf(false),
+		},
+		args: []any{true, false},
+	},
+	"int": {
+		values: []reflect.Value{
+			reflect.ValueOf(1), reflect.ValueOf(2),
+		},
+		args: []any{1, 2},
+	},
+	"string": {
+		values: []reflect.Value{
+			reflect.ValueOf("value"), reflect.ValueOf("other"),
+		},
+		args: []any{"value", "other"},
+	},
+	"stringptr": {
+		values: []reflect.Value{
+			reflect.ValueOf(&teststring), reflect.ValueOf(&teststring),
+		},
+		args: []any{&teststring, &teststring},
+	},
+
+	"array": {
+		values: []reflect.Value{
+			reflect.ValueOf(testarray), reflect.ValueOf(testarray),
+		},
+		args: []any{testarray, testarray},
+	},
+	"slice": {
+		values: []reflect.Value{
+			reflect.ValueOf(testslice), reflect.ValueOf(testslice),
+		},
+		args: []any{testslice, testslice},
+	},
+	"map": {
+		values: []reflect.Value{
+			reflect.ValueOf(testmap), reflect.ValueOf(testmap),
+		},
+		args: []any{testmap, testmap},
+	},
+	"struct": {
+		values: []reflect.Value{
+			reflect.ValueOf(teststruct), reflect.ValueOf(teststruct),
+		},
+		args: []any{teststruct, teststruct},
+	},
+	"chan": {
+		values: []reflect.Value{
+			reflect.ValueOf(testchan),
+		},
+		args: []any{testchan},
+	},
+}
+
+func TestArgsOf(t *testing.T) {
+	test.Map(t, testArgsOfParams).
+		Run(func(t test.Test, param ArgsOfParams) {
+			// When
+			args := reflect.ArgsOf(param.values...)
+
+			// Then
+			assert.Equal(t, param.args, args)
+		})
+}
+
+type ValuesParams struct {
+	setup  mock.SetupFunc
+	call   any
+	args   []any
+	expect test.Expect
+}
+
+var testValuesInParams = map[string]ValuesParams{
+	"args-nil": {
+		setup: test.Panic("not enough arguments"),
+		call:  func(any) {},
+		args:  nil,
+	},
+	"args-nil-var": {
+		call:   func(...any) {},
+		args:   nil,
+		expect: test.Success,
+	},
+
+	"nil": {
+		call:   func(any, any) {},
+		args:   []any{nil, nil},
+		expect: test.Success,
+	},
+	"nil-less": {
+		setup: test.Panic("not enough arguments"),
+		call:  func(any, any) {},
+		args:  []any{nil},
+	},
+	"nil-more": {
+		setup: test.Panic("too many arguments"),
+		call:  func(any) {},
+		args:  []any{nil, nil},
+	},
+	"nil-var": {
+		call:   func(any, ...any) {},
+		args:   []any{nil},
+		expect: test.Success,
+	},
+	"nil-var-less": {
+		setup: test.Panic("not enough arguments"),
+		call:  func(any, ...any) {},
+		args:  []any{},
+	},
+	"nil-var-first": {
+		call:   func(any, ...any) {},
+		args:   []any{nil, nil},
+		expect: test.Success,
+	},
+	"nil-var-more": {
+		call:   func(any, ...any) {},
+		args:   []any{nil, nil, nil},
+		expect: test.Success,
+	},
+
+	"match": {
+		call:   func(bool, int, string, ExportParams) {},
+		args:   []any{true, 1, "value", teststruct},
+		expect: test.Success,
+	},
+	"match-var": {
+		call:   func(bool, int, string, ExportParams, ...any) {},
+		args:   []any{true, 1, "value", teststruct},
+		expect: test.Success,
+	},
+	"match-var-less": {
+		setup: test.Panic("not enough arguments"),
+		call:  func(bool, int, string, ExportParams) {},
+		args:  []any{true, 1, "value"},
+	},
+	"match-var-more": {
+		call:   func(bool, int, string, ExportParams, ...any) {},
+		args:   []any{true, 1, "value", teststruct, true, 1, "value"},
+		expect: test.Success,
+	},
+
+	"miss": {
+		setup: test.Panic(reflect.ErrInvalidType(
+			1, reflect.TypeOf(1), reflect.TypeOf(""))),
+		call: func(bool, int) {},
+		args: []any{true, "value"},
+	},
+	"miss-var": {
+		setup: test.Panic(reflect.ErrInvalidType(
+			1, reflect.TypeOf(true), reflect.TypeOf(0))),
+		call: func(bool, ...bool) {},
+		args: []any{true, 1, "value"},
+	},
+}
+
+func TestValuesIn(t *testing.T) {
+	test.Map(t, testValuesInParams).
+		Run(func(t test.Test, param ValuesParams) {
+			// Given
+			mock.NewMock(t).Expect(param.setup)
+			ftype := reflect.TypeOf(param.call)
+
+			// When
+			values := reflect.ValuesIn(ftype, param.args...)
+
+			// Then (reflect.Values are not comparable)
+			assert.Equal(t, param.args, reflect.ArgsOf(values...))
+		})
+}
+
+var testValuesOutParams = map[string]ValuesParams{
+	"method-nil": {
+		call:   func() {},
+		args:   nil,
+		expect: test.Success,
+	},
+	"method-empty": {
+		call: func() {},
+		args: []any{},
+	},
+	"method-more": {
+		setup: test.Panic("too many arguments"),
+		call:  func() {},
+		args:  []any{nil},
+	},
+
+	"nil": {
+		call:   func() (any, any) { return nil, nil },
+		args:   []any{nil, nil},
+		expect: test.Success,
+	},
+	"nil-less": {
+		setup: test.Panic("not enough arguments"),
+		call:  func() (any, any) { return nil, nil },
+		args:  []any{nil},
+	},
+	"nil-more": {
+		setup: test.Panic("too many arguments"),
+		call:  func() any { return nil },
+		args:  []any{nil, nil},
+	},
+
+	"match": {
+		call: func() (bool, int, string, ExportParams) {
+			return true, 1, "value", teststruct
+		},
+		args:   []any{true, 1, "value", teststruct},
+		expect: test.Success,
+	},
+
+	"miss": {
+		setup: test.Panic(reflect.ErrInvalidType(
+			1, reflect.TypeOf(true), reflect.TypeOf(1))),
+		call: func() (bool, bool) { return true, true },
+		args: []any{true, 1},
+	},
+}
+
+func TestValuesOut(t *testing.T) {
+	test.Map(t, testValuesOutParams).
+		Run(func(t test.Test, param ValuesParams) {
+			// Given
+			mock.NewMock(t).Expect(param.setup)
+			ftype := reflect.TypeOf(param.call)
+
+			// When
+			values := reflect.ValuesOut(ftype, param.args...)
+
+			// Then (reflect.Values are not comparable)
+			assert.Equal(t, param.args, reflect.ArgsOf(values...))
+		})
+}
+
+type AnyFuncOfParams struct {
+	args     int
+	variadic bool
+	expect   any
+}
+
+var testAnyFuncOfParams = map[string]AnyFuncOfParams{
+	"args-0": {
+		args: 0, variadic: false, expect: func() {},
+	},
+	"args-1": {
+		args: 1, variadic: false, expect: func(any) {},
+	},
+	"args-1-var": {
+		args: 1, variadic: true, expect: func(...any) {},
+	},
+	"args-2": {
+		args: 2, variadic: false, expect: func(any, any) {},
+	},
+	"args-2-var": {
+		args: 2, variadic: true, expect: func(any, ...any) {},
+	},
+	"args-4": {
+		args: 4, variadic: false, expect: func(any, any, any, any) {},
+	},
+	"args-4-var": {
+		args: 4, variadic: true, expect: func(any, any, any, ...any) {},
+	},
+}
+
+func TestAnyFuncOf(t *testing.T) {
+	test.Map(t, testAnyFuncOfParams).
+		Run(func(t test.Test, param AnyFuncOfParams) {
+			// Given
+
+			// When
+			ftype := reflect.AnyFuncOf(param.args, param.variadic)
+
+			// Then
+			assert.Equal(t, reflect.TypeOf(param.expect), ftype)
+		})
+}
+
+type BaseFuncOfParams struct {
+	call    any
+	in, out int
+	expect  any
+}
+
+var testBaseFuncOfParams = map[string]BaseFuncOfParams{
+	"in-0-out-0": {
+		call:   func() {},
+		expect: func() {},
+	},
+	"in-1-out-0": {
+		call:   func(any) {},
+		expect: func(any) {},
+	},
+	"in-2-out-0": {
+		call:   func(any, string) {},
+		expect: func(any, string) {},
+	},
+
+	"in-2(1)-out-0": {
+		in:     1,
+		call:   func(any, string) {},
+		expect: func(string) {},
+	},
+	"in-2(0)-out-0": {
+		in:     2,
+		call:   func(any, string) {},
+		expect: func() {},
+	},
+
+	"in-1-out-1": {
+		call:   func(any) int { return 1 },
+		expect: func(any) int { return 1 },
+	},
+	"in-1-out-2": {
+		call:   func(any) (int, error) { return 1, nil },
+		expect: func(any) (int, error) { return 1, nil },
+	},
+	"in-2-out-1": {
+		call:   func(any, string) int { return 1 },
+		expect: func(any, string) int { return 1 },
+	},
+	"in-2-out-2": {
+		call:   func(any, string) (int, error) { return 1, nil },
+		expect: func(any, string) (int, error) { return 1, nil },
+	},
+
+	"in-1(0)-out-1(0)": {
+		in: 1, out: 1,
+		call:   func(any) int { return 1 },
+		expect: func() {},
+	},
+	"in-1(0)-out-2(1)": {
+		in: 1, out: 1,
+		call:   func(any) (int, error) { return 1, nil },
+		expect: func() error { return nil },
+	},
+	"in-2(0)-out-1(0)": {
+		in: 2, out: 2,
+		call:   func(any, string) int { return 1 },
+		expect: func() {},
+	},
+	"in-2(0)-out-2(0)": {
+		in: 2, out: 2,
+		call:   func(any, string) (int, error) { return 1, nil },
+		expect: func() {},
+	},
+}
+
+func TestBaseFuncOf(t *testing.T) {
+	test.Map(t, testBaseFuncOfParams).
+		Run(func(t test.Test, param BaseFuncOfParams) {
+			// Given
+			ctype := reflect.TypeOf(param.call)
+
+			// When
+			ftype := reflect.BaseFuncOf(ctype, param.in, param.out)
+
+			// Then
+			assert.Equal(t, reflect.TypeOf(param.expect), ftype)
+		})
+}
+
+type MakeFuncOfParams struct {
+	call       any
+	args       []any
+	result     []any
+	expectArgs []any
+}
+
+var testMakeFuncOfParams = map[string]MakeFuncOfParams{
+	"in-0-out-0": {
+		call: func() {},
+	},
+	"in-1-out-1": {
+		call:       func(any) int { return 1 },
+		args:       []any{teststruct},
+		result:     []any{1},
+		expectArgs: []any{teststruct},
+	},
+	"in-2-out-2": {
+		call:       func(any, string) (int, error) { return 1, nil },
+		args:       []any{teststruct, teststring},
+		result:     []any{1, errors.New("any")},
+		expectArgs: []any{teststruct, teststring},
+	},
+	"in-2-var-out-2": {
+		call:       func(any, ...string) (int, error) { return 1, nil },
+		args:       []any{teststruct, teststring, "string-2", "string-3"},
+		result:     []any{1, errors.New("any")},
+		expectArgs: []any{teststruct, []string{teststring, "string-2", "string-3"}},
+	},
+}
+
+func TestMakeFuncOf(t *testing.T) {
+	test.Map(t, testMakeFuncOfParams).
+		Run(func(t test.Test, param MakeFuncOfParams) {
+			// Given
+			ctype := reflect.TypeOf(param.call)
+
+			// When
+			call := reflect.MakeFuncOf(ctype,
+				func(args []reflect.Value) []reflect.Value {
+					assert.Equal(t, param.expectArgs, reflect.ArgsOf(args...))
+					return reflect.ValuesOut(ctype, param.result...)
+				})
+
+			// Then
+			ftype := reflect.TypeOf(call)
+			assert.Equal(t, ctype, ftype)
+
+			// When
+			result := reflect.ArgsOf(reflect.ValueOf(call).Call(
+				reflect.ValuesIn(ftype, param.args...),
+			)...)
+
+			// Then
+			assert.Equal(t, param.result, result)
+		})
 }

--- a/internal/sync/waitgroup.go
+++ b/internal/sync/waitgroup.go
@@ -1,3 +1,6 @@
+// Package sync contains a small collection of helpful generic functions and
+// types for synchronization. It is currently part of the public interface and
+// stable, but this may change in future.
 package sync
 
 import "sync"

--- a/internal/sync/waitgroup_test.go
+++ b/internal/sync/waitgroup_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tkrop/go-testing/sync"
+	"github.com/tkrop/go-testing/internal/sync"
 )
 
 func TestWaitGroup(t *testing.T) {

--- a/perm/perm_test.go
+++ b/perm/perm_test.go
@@ -20,8 +20,7 @@ type IFace interface {
 func CallA(input string) mock.SetupFunc {
 	return func(mocks *mock.Mocks) any {
 		return mock.Get(mocks, NewMockIFace).EXPECT().
-			CallA(input).Times(mocks.Times(1)).
-			Do(mocks.GetDone(1))
+			CallA(input).Do(mocks.Return(IFace.CallA))
 	}
 }
 

--- a/test/caller_test.go
+++ b/test/caller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+
 	"github.com/tkrop/go-testing/mock"
 	"github.com/tkrop/go-testing/test"
 )

--- a/test/gomock.go
+++ b/test/gomock.go
@@ -1,0 +1,164 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/tkrop/go-testing/internal/reflect"
+	"github.com/tkrop/go-testing/mock"
+)
+
+// Validator a test failure validator based on the thest reporter interface.
+type Validator struct {
+	ctrl     *gomock.Controller
+	recorder *Recorder
+}
+
+// Recorder a test failure validator recorder.
+type Recorder struct {
+	validator *Validator
+}
+
+// NewValidator creates a new test validator for validating error messages and
+// panics created during test execution.
+func NewValidator(ctrl *gomock.Controller) *Validator {
+	validator := &Validator{ctrl: ctrl}
+	validator.recorder = &Recorder{validator: validator}
+	if t, ok := ctrl.T.(*Tester); ok {
+		ctrl.T = NewTester(t.t, Success)
+		t.Reporter(validator)
+	}
+	return validator
+}
+
+// EXPECT implements the usual `gomock.EXPECT` call to request the recorder.
+func (v *Validator) EXPECT() *Recorder {
+	return v.recorder
+}
+
+// Errorf receive expected method call to `Errorf`.
+func (v *Validator) Errorf(format string, args ...any) {
+	v.ctrl.T.Helper()
+	v.ctrl.Call(v, "Errorf", append([]any{format}, args...)...)
+}
+
+// Errorf indicate an expected method call to `Errorf`.
+func (r *Recorder) Errorf(format string, args ...any) *gomock.Call {
+	r.validator.ctrl.T.Helper()
+	return r.validator.ctrl.RecordCallWithMethodType(r.validator, "Errorf",
+		reflect.TypeOf((*Validator)(nil).Errorf),
+		append([]any{format}, args...)...)
+}
+
+// Errorf creates a validation method call setup for `Errorf`.
+func Errorf(format string, args ...any) mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewValidator).EXPECT().
+			Errorf(format, args...).
+			Do(mocks.Return(Reporter.Errorf))
+	}
+}
+
+// Fatalf receive expected method call to `Fatalf`.
+func (v *Validator) Fatalf(format string, args ...any) {
+	v.ctrl.T.Helper()
+	v.ctrl.Call(v, "Fatalf", append([]any{format}, args...)...)
+}
+
+// Fatalf indicate an expected method call to `Fatalf`.
+func (r *Recorder) Fatalf(format string, args ...any) *gomock.Call {
+	r.validator.ctrl.T.Helper()
+	return r.validator.ctrl.RecordCallWithMethodType(r.validator, "Fatalf",
+		reflect.TypeOf((*Validator)(nil).Fatalf),
+		append([]any{format}, args...)...)
+}
+
+// Fatalf creates a validation method call setup for `Fatalf`.
+func Fatalf(format string, args ...any) mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewValidator).EXPECT().
+			Fatalf(format, args...).Do(mocks.Return(Reporter.Fatalf))
+	}
+}
+
+// FailNow receive expected method call to `FailNow`.
+func (v *Validator) FailNow() {
+	v.ctrl.T.Helper()
+	v.ctrl.Call(v, "FailNow")
+}
+
+// FailNow indicate an expected method call to `FailNow`.
+func (r *Recorder) FailNow() *gomock.Call {
+	r.validator.ctrl.T.Helper()
+	return r.validator.ctrl.RecordCallWithMethodType(r.validator, "FailNow",
+		reflect.TypeOf((*Validator)(nil).FailNow))
+}
+
+// FailNow creates a validation method call setup for `FailNow`.
+func FailNow() mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewValidator).EXPECT().
+			FailNow().Do(mocks.Return(Reporter.FailNow))
+	}
+}
+
+// Panic receive expected method call indicating a panic.
+func (v *Validator) Panic(arg any) {
+	v.ctrl.T.Helper()
+	v.ctrl.Call(v, "Panic", []any{arg}...)
+}
+
+// Panic indicate an expected method call from panic.
+func (r *Recorder) Panic(arg any) *gomock.Call {
+	r.validator.ctrl.T.Helper()
+	return r.validator.ctrl.RecordCallWithMethodType(r.validator, "Panic",
+		reflect.TypeOf((*Validator)(nil).Panic), []any{arg}...)
+}
+
+// Panic creates a validation method call setup for a panic. It allows to match
+// the panic object, which usually is an error and alternatively the error
+// string representing the error, since runtime errors may be irreproducible.
+func Panic(arg any) mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewValidator).EXPECT().
+			Panic(Error(arg)).Do(mocks.Return(Reporter.Panic))
+	}
+}
+
+// errorMatcher is an error matcher to improve capabilities of matching errors.
+type errorMatcher struct {
+	x any
+}
+
+// Error creates a new error matcher that allows to match either the error or
+// alternatively the string describing the error.
+func Error(x any) gomock.Matcher {
+	return &errorMatcher{x: x}
+}
+
+// Matches executes the extended error matching.
+func (m *errorMatcher) Matches(x any) bool {
+	switch a := m.x.(type) {
+	case string:
+		switch b := x.(type) {
+		case string:
+			return gomock.Eq(a).Matches(b)
+		case error:
+			return gomock.Eq(a).Matches(b.Error())
+		}
+	case error:
+		switch b := x.(type) {
+		case string:
+			return gomock.Eq(a.Error()).Matches(b)
+		case error:
+			return gomock.Eq(a).Matches(b)
+		}
+	}
+	return gomock.Eq(m.x).Matches(x)
+}
+
+// String creates a string of the expectation to match.
+func (m *errorMatcher) String() string {
+	return fmt.Sprintf("is equal to %v (%T)", m.x, m.x)
+}

--- a/test/gomock_test.go
+++ b/test/gomock_test.go
@@ -1,0 +1,88 @@
+package test_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tkrop/go-testing/test"
+)
+
+type ErrorMatcherParams struct {
+	base   any
+	match  any
+	result bool
+}
+
+var testErrorMatcherParams = map[string]ErrorMatcherParams{
+	"success-string-string": {
+		base:   "error",
+		match:  "error",
+		result: true,
+	},
+	"success-string-error": {
+		base:   "error",
+		match:  errors.New("error"),
+		result: true,
+	},
+	"success-error-string": {
+		base:   errors.New("error"),
+		match:  "error",
+		result: true,
+	},
+	"success-error-error": {
+		base:   errors.New("error"),
+		match:  errors.New("error"),
+		result: true,
+	},
+	"success-other-other": {
+		base:   1,
+		match:  1,
+		result: true,
+	},
+
+	"failure-string-string": {
+		base:   "error",
+		match:  "error-other",
+		result: false,
+	},
+	"failure-string-error": {
+		base:   "error",
+		match:  errors.New("error-other"),
+		result: false,
+	},
+	"failure-error-string": {
+		base:   errors.New("error"),
+		match:  "error-other",
+		result: false,
+	},
+	"failure-error-error": {
+		base:   errors.New("error"),
+		match:  errors.New("error-other"),
+		result: false,
+	},
+	"failure-other-other": {
+		base:   1,
+		match:  false,
+		result: false,
+	},
+}
+
+func TestErrorMatcher(t *testing.T) {
+	test.Map(t, testErrorMatcherParams).
+		Run(func(t test.Test, param ErrorMatcherParams) {
+			// Given
+			matcher := test.Error(param.base)
+
+			// When
+			result := matcher.Matches(param.match)
+
+			// Then
+			assert.Equal(t, param.result, result)
+		})
+}
+
+func TestErrorMatcherString(t *testing.T) {
+	assert.Equal(t, test.Error(true).String(), "is equal to true (bool)")
+}

--- a/test/testing_test.go
+++ b/test/testing_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/tkrop/go-testing/internal/sync"
+
 	"github.com/tkrop/go-testing/mock"
-	"github.com/tkrop/go-testing/sync"
 	"github.com/tkrop/go-testing/test"
 )
 


### PR DESCRIPTION
This pull request redesigns and simplifies the mock setup containing sync-calls by integrating it completely into the `Do`/`DoAndReturn` setup support and improves the test validation support.