### PR TITLE
feat: improve linting (#36)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -3,3 +3,6 @@ engines:
     minTokenMatch: 50
     exclude_paths:
       - "**/*_test.go"
+  revive:
+    exclude_paths:
+      - "**/mock_*_test.go"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,7 @@ issues:
 
   exclude-rules:
     - source: "^//\\s*go:generate\\s"
-      linters: [ lll ]
+      linters: [ lll, revive ]
     - source: "(noinspection|TODO)"
       linters: [ godot ]
     - source: "//noinspection"
@@ -26,6 +26,10 @@ issues:
         - gosec
         - noctx
         - wrapcheck
+    - path: "_test\\.go"
+      linters: [ revive ]
+      text: "^(max-public-structs|function-length|cognitive-complexity):"
+
 
 # This contains only configs which differ from defaults. For other configs see
 # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
@@ -97,3 +101,69 @@ linters-settings:
     # `*testing.B`, and `testing.TB` as arguments are checked.
     # Default: false
     all: true
+
+  revive:
+    # Enable all available rules.
+    # Default: false
+    enable-all-rules: true
+    # When set to false, ignores files with "GENERATED" header, similar to golint.
+    # See https://github.com/mgechev/revive#available-rules for details.
+    # Default: false
+    ignore-generated-header: true
+    # Sets the default severity.
+    # See https://github.com/mgechev/revive#configuration
+    # Default: warning
+    severity: error
+    rules:
+      # No need to enforce a file header.
+      - name: file-header
+        disabled: true
+      # Reports on each file in a package.
+      - name: package-comments
+        disabled: true
+      # Reports on comments mismatching comments.
+      - name: exported
+        disabled: true
+      # No need to exclude import shadowing.
+      - name: import-shadowing
+        disabled: true
+      # Failes to exclude nolint directives from reporting.
+      - name: comment-spacings
+        disabled: true
+      # Fails to disable writers that actually cannot return errors.
+      - name: unhandled-error
+        disabled: true
+      # Fails to restrict sufficiently in switches with numeric values.
+      - name: add-constant
+        disabled: true
+      # Rule prevents intentional usage of similar variable names.
+      - name: flag-parameter
+        disabled: true
+
+      # Enables a more experienced cyclomatic complexity (we enabled a log of
+      # rules to counter-act the complexity trap).
+      - name: cyclomatic
+        arguments: [20]
+      # Enables a more experienced cognitive complexity (we enabled a lot of
+      # rules to counter-act the complexity tryp).
+      - name: cognitive-complexity
+        arguments: [20]
+      # Limit line-length to increase readability.
+      - name: line-length-limit
+        disabled: false
+        arguments: [100]
+      # We are a bit more relexed with function length consistent with funlen.
+      - name: function-length
+        arguments: [40, 60]
+      # Limit arguments of functions to the maximum understandable value.
+      - name: argument-limit
+        arguments: [6]
+      # Limit results of functions to the maximum understandable value.
+      - name: function-result-limit
+        arguments: [4]
+      # Raise the limit a bit to allow more complex package models.
+      - name: max-public-structs
+        arguments: [8]
+      # I do not know what I'm doing here...
+      - name: banned-characters
+        arguments: ["Ω", "Σ", "σ", "7"]

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,35 @@
+# Default state for all rules
+default: true
+
+# MD012/no-multiple-blanks - Multiple consecutive blank lines
+MD012:
+  # Consecutive blank lines
+  maximum: 3
+
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 80
+  # Number of characters for headings
+  heading_line_length: 80
+  # Number of characters for code blocks
+  code_block_line_length: 80
+  # Include code blocks
+  code_blocks: true
+  # Include tables
+  tables: true
+  # Include headings
+  headings: true
+  # Include headings
+  headers: true
+  # Strict length checking
+  strict: true
+  # Stern length checking
+  stern: false
+
+# MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+MD022:
+  # Blank lines above heading
+  lines_above: 2
+  # Blank lines below heading
+  lines_below: 1

--- a/MAKEFILE.md
+++ b/MAKEFILE.md
@@ -66,13 +66,14 @@ The [Makefile](Makefile) supports different targets that can help with linting
 as well as with fixing the linter problems - if possible.
 
 ```bash
-make lint        # short cut to execute 'lint-base lint-apis'
-make lint-base   # lints the go-code using a baseline setting
-make lint-plus   # lints the go-code using an advanced setting
-make lint-all    # lints the go-code using an all-in expert setting
-make lint-api    # lints the api specifications in '/zalando-apis'
+make lint         # short cut to execute 'lint-base lint-revive lint-apis'
+make lint-base    # lints the go-code using a baseline settings
+make lint-plus    # lints the go-code using an advanced settings
+make lint-all     # lints the go-code using an all-in expert settings
+make lint-revive  # lints the go-code using the codacy revive settings
+make lint-api     # lints the api specifications in '/zalando-apis'
 
-make format      # formats the code to fix selected linter violations
+make format       # formats the code to fix selected linter violations
 ```
 
 The `lint-*` targets allow command line arguments:
@@ -118,8 +119,8 @@ If a command, service, job has not been build before, it is first build.
 The delete targets delete the latest installed command from `${GOPATH}/bin`.
 
 ```bash
-make install      # Deletes all commands
-make install-(*)  # Deletes the matched command
+make delete      # Deletes all commands
+make delete-(*)  # Deletes the matched command
 ```
 
 **Note:** Please use carefully, if your project uses common command names.

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TEMPDIR := $(RUNDIR)/temp
 TEST_ALL := $(BUILDIR)/test-all.cover
 TEST_UNIT := $(BUILDIR)/test-unit.cover
 TEST_BENCH := $(BUILDIR)/test-bench.cover
-LINT_ALL := lint-base lint-apis
+LINT_ALL := lint-base lint-revive lint-apis
 
 # Include required custom variables.
 ifneq ("$(wildcard Makefile.vars)","")
@@ -47,6 +47,7 @@ TOOLS ?= github.com/golang/mock/mockgen@latest \
 	github.com/tkrop/go-testing/cmd/mock@latest \
 	github.com/zalando/zally/cli/zally@latest \
 	github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
+	github.com/mgechev/revive@latest \
 	golang.org/x/tools/cmd/goimports@latest \
 	mvdan.cc/gofumpt@latest \
 	github.com/daixiang0/gci@latest \
@@ -159,7 +160,7 @@ MOCKS := $(shell for TARGET in $(MOCK_TARGETS); \
 .PHONY: $(addprefix clean-run-, $(COMMANDS) db aws)
 .PHONY: init init-tools init-hooks init-packages init-sources
 .PHONY: test test-all test-unit test-bench test-clean test-upload test-cover
-.PHONY: lint lint-base lint-plus lint-all lint-apis format
+.PHONY: lint lint-base lint-plus lint-all lint-revive lint-apis format
 .PHONY: build build-native build-linux build-image build-docker
 .PHONY: $(addprefix build-, $(COMMANDS))
 .PHONY: install $(addprefix install-, $(COMMANDS))
@@ -262,6 +263,8 @@ update-make:
 	    git show HEAD:Makefile > Makefile; \
 		git show HEAD:MAKEFILE.md > MAKEFILE.md; \
 		git show HEAD:.golangci.yaml > .golangci.yaml; \
+		git show HEAD:.codacy.yaml > .codacy.yaml; \
+		git show HEAD:revive.toml > revive.toml; \
 	  cd - \
 	); cp $${TEMPDIR}/Makefile $${TEMPDIR}/MAKEFILE.md .; \
 	rm -rf $${TEMPDIR}; \
@@ -466,6 +469,9 @@ lint-plus: init-sources
 	golangci-lint $(LINT_CMD) $(LINT_ADVANCED);
 lint-all: init-sources
 	golangci-lint $(LINT_CMD) $(LINT_EXPERT);
+
+lint-revive: init-sources
+	revive -formatter friendly -config=revive.toml $(SOURCES);
 
 lint-apis:
 	@LINTER="https://infrastructure-api-linter.zalandoapis.com"; \

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/h2non/gock v1.2.0
 	github.com/huandu/go-clone v1.5.0
 	github.com/stretchr/testify v1.8.2
-	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
+	golang.org/x/exp v0.0.0-20230304125523-9ff063c70017
 	golang.org/x/text v0.6.0
 	golang.org/x/tools v0.6.0
 )
@@ -16,7 +16,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.8.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/mod v0.9.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,11 +26,11 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230304125523-9ff063c70017 h1:3Ea9SZLCB0aRIhSEjM+iaGIlzzeDJdpi579El/YIhEE=
+golang.org/x/exp v0.0.0-20230304125523-9ff063c70017/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
-golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -42,8 +42,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/gock/controller.go
+++ b/gock/controller.go
@@ -85,7 +85,7 @@ func (ctrl *Controller) InterceptClient(client *http.Client) {
 
 // RestoreClient allows to disable and restore the original transport in the
 // given http.Client.
-func (ctrl *Controller) RestoreClient(client *http.Client) {
+func (ctrl *Controller) RestoreClient(client *http.Client) { //revive:disable-line
 	if transport, ok := client.Transport.(*Transport); ok {
 		client.Transport = transport.transport
 	}

--- a/internal/mock/loader.go
+++ b/internal/mock/loader.go
@@ -40,7 +40,7 @@ type PkgResponse struct {
 // derived default package names - usually ony applied on not-now-existing
 // packages.
 func NewPkgResponse(
-	path string, pkgs []*packages.Package, err error,
+	_ string, pkgs []*packages.Package, err error,
 ) *PkgResponse {
 	for _, pkg := range pkgs {
 		// TODO: simplify package path logic for caching etc.
@@ -176,6 +176,8 @@ func (loader *CachedLoader) byPath(path string) *PkgResponse {
 // file, the package is resolved but will not provide the package repository
 // path nor the standardized package name by default. The method compensates
 // this partially be calculating default package names on a best effort basis.
+//
+//revive:disable-next-line // internal implementation.
 func (loader *CachedLoader) load(path string) *PkgResponse {
 	pkgs, err := packages.Load(loader.Config, path)
 	if err != nil {
@@ -238,7 +240,7 @@ func (loader *CachedLoader) ifacesAny(
 
 // iface looks up a single interface from the given package that matches the
 // provided interface name.
-func (loader *CachedLoader) iface(
+func (loader *CachedLoader) iface( //revive:disable-line // keep namespace clean.
 	pkg *packages.Package, source *Type, name string,
 ) (*types.TypeName, *types.Interface, error) {
 	if object := pkg.Types.Scope().Lookup(name); object == nil {
@@ -266,6 +268,8 @@ func (loader *CachedLoader) normalize(path string) string {
 // trimfile removes the last part of the file path, if it is a file or if the
 // part does not exist. This is following the assumption that a valid target
 // package needs to exist to generate code or read a package.
+//
+//revive:disable-next-line // keep namespace clean.
 func (loader *CachedLoader) trimfile(path string) string {
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {

--- a/internal/mock/test/iface.go
+++ b/internal/mock/test/iface.go
@@ -14,6 +14,7 @@ import (
 // IFace is an interface for testing.
 type IFace interface {
 	CallA(value *Struct, args ...*reflect.Value) ([]any, error)
+	//revive:disable-next-line // used for testing.
 	CallB() (fn func([]*mock.File) []interface{}, err error)
 	CallC(test test.Tester)
 }

--- a/internal/mock/testx/iface.go
+++ b/internal/mock/testx/iface.go
@@ -14,6 +14,7 @@ import (
 // IFace is an interface for testing.
 type IFace interface {
 	CallA(value *Struct, args ...*reflect.Value) ([]any, error)
+	//revive:disable-next-line // used for testing.
 	CallB() (fn func([]*mock.File) []interface{}, err error)
 	CallC(test test.Tester)
 }

--- a/revive.toml
+++ b/revive.toml
@@ -1,0 +1,86 @@
+# Translates the 'golangci-lint' settings into an codacy understandable format.
+
+# When set to false, ignores files with "GENERATED" header, similar to golint
+ignoreGeneratedHeader = true
+
+# Sets the default severity to "warning"
+severity = "error"
+
+# Sets the default failure confidence. This means that linting errors
+# with less than 0.8 confidence will be ignored.
+confidence = 0.8
+
+# Sets the error code for failures with severity "error"
+errorCode = 1
+
+# Sets the error code for failures with severity "warning"
+warningCode = 0
+
+# Enables all available rules
+enableAllRules = true
+
+# No need to enforce a file header.
+[rule.file-header]
+  disabled = true
+
+# Reports on each file in a package.
+[rule.package-comments]
+  disabled = true
+
+# Reports on comments mismatching comments.
+[rule.exported]
+  disabled = true
+
+# No need to exclude import shadowing.
+[rule.import-shadowing]
+  disabled = true
+
+# Fails to exclude nolint directives from reporting.
+[rule.comment-spacings]
+  disabled = true
+
+# Fails to disable writers that actually cannot return errors.
+[rule.unhandled-error]
+  disabled = true
+
+# Fails to restrict sufficiently in switches with numeric values.
+[rule.add-constant]
+  disabled = true
+
+# Rule prevents intentional usage of similar variable names.
+[rule.flag-parameter]
+  disabled = true
+
+# Enables a more experienced cyclomatic complexity (we enabled a log of rules
+# to counter-act the complexity trap).
+[rule.cyclomatic]
+  arguments = [20]
+
+# Enables a more experienced cognitive complexity (we enabled a lot of rules
+# to counter-act the complexity tryp).
+[rule.cognitive-complexity]
+  arguments = [20]
+
+# Limit line-length to increase readability.
+[rule.line-length-limit]
+  arguments = [100]
+
+# We are a bit more relexed with function length consistent with funlen.
+[rule.function-length]
+  arguments = [40,60]
+
+# Limit arguments of functions to the maximum understandable value.
+[rule.argument-limit]
+  arguments = [6]
+
+# Limit results of functions to the maximum understandable value.
+[rule.function-result-limit]
+  arguments = [4]
+
+# Raise the limit a bit to allow more complex package models.
+[rule.max-public-structs]
+  arguments = [8]
+
+# I do not know what I'm doing here...
+[rule.banned-characters]
+  arguments = ["Ω", "Σ", "σ", "7"]

--- a/test/caller_test.go
+++ b/test/caller_test.go
@@ -20,14 +20,14 @@ type Caller struct {
 
 // Errorf is the caller reporter function to capture the callers file and line
 // number of the `Errorf` call.
-func (c *Caller) Errorf(format string, args ...any) {
+func (c *Caller) Errorf(_ string, _ ...any) {
 	_, path, line, _ := runtime.Caller(1)
 	c.path = path + ":" + strconv.Itoa(line)
 }
 
 // Fatalf is the caller reporter function to capture the callers file and line
 // number of the `Fatalf` call.
-func (c *Caller) Fatalf(format string, args ...any) {
+func (c *Caller) Fatalf(_ string, _ ...any) {
 	_, path, line, _ := runtime.Caller(1)
 	c.path = path + ":" + strconv.Itoa(line)
 	panic("finished") // prevents goexit.
@@ -41,7 +41,7 @@ func (c *Caller) FailNow() {
 	panic("finished") // prevents goexit.
 }
 
-func (c *Caller) Panic(arg any) {
+func (c *Caller) Panic(_ any) {
 	_, path, line, _ := runtime.Caller(1)
 	c.path = path + ":" + strconv.Itoa(line)
 	panic("finished") // prevents goexit.

--- a/test/testing.go
+++ b/test/testing.go
@@ -134,6 +134,8 @@ func (t *Tester) Parallel() {
 }
 
 // WaitGroup adds wait group to unlock in case of a failure.
+//
+//revive:disable-next-line // is using a wrapper interface similar named.
 func (t *Tester) WaitGroup(wg sync.WaitGroup) {
 	t.wg = wg
 }
@@ -271,7 +273,7 @@ func (t *Tester) register() {
 }
 
 // cleanup runs the cleanup methods registered on the isolated test environment.
-func (t *Tester) cleanup() {
+func (t *Tester) cleanup() { //revive:disable-line // internal implementation.
 	t.mu.Lock()
 	cleanups := slices.Reverse(t.cleanups)
 	t.mu.Unlock()
@@ -302,6 +304,8 @@ func (t *Tester) finish() {
 // recover recovers from panics and generate test failure.
 func (t *Tester) recover() {
 	t.Helper()
+
+	//revive:disable-next-line // this is inside the defered function.
 	if arg := recover(); arg != nil {
 		t.Panic(arg)
 	}
@@ -385,7 +389,7 @@ func (r *runner[P]) RunSeq(call func(t Test, param P)) Runner[P] {
 }
 
 // Run runs the test parameter sets either parallel or in sequence.
-func (r *runner[P]) run(
+func (r *runner[P]) run( //revive:disable-line // internal implementation.
 	call func(t Test, param P), parallel bool,
 ) Runner[P] {
 	switch params := r.params.(type) {
@@ -443,7 +447,7 @@ func (r *runner[P]) wrap(
 }
 
 // name resolves the test case name from the parameter set.
-func (r *runner[P]) name(param P) Name {
+func (r *runner[P]) name(param P) Name { //revive:disable-line // generic.
 	name, ok := reflect.FindArgOf(param, unknownName, "name").(Name)
 	if ok && name != "" {
 		return name
@@ -452,7 +456,7 @@ func (r *runner[P]) name(param P) Name {
 }
 
 // expect resolves the test case expectation from the parameter set.
-func (r *runner[P]) expect(param P) Expect {
+func (r *runner[P]) expect(param P) Expect { //revive:disable-line // generic.
 	if expect, ok := reflect.FindArgOf(param, Success, "expect").(Expect); ok {
 		return expect
 	}
@@ -462,6 +466,8 @@ func (r *runner[P]) expect(param P) Expect {
 // Run creates an isolated (by default) parallel test environment running the
 // given test function with given expectation. When executed via `t.Run()` it
 // checks whether the result is matching the expectation.
+//
+//revive:disable-next-line // external interface without receiver.
 func Run(expect Expect, test func(Test)) func(*testing.T) {
 	return run(expect, test, Parallel)
 }
@@ -469,6 +475,8 @@ func Run(expect Expect, test func(Test)) func(*testing.T) {
 // RunSeq creates an isolated, test environment for the given test function
 // with given expectation. When executed via `t.Run()` it checks whether the
 // result is matching the expectation.
+//
+//revive:disable-next-line // external interface without receiver.
 func RunSeq(expect Expect, test func(Test)) func(*testing.T) {
 	return run(expect, test, false)
 }
@@ -476,6 +484,8 @@ func RunSeq(expect Expect, test func(Test)) func(*testing.T) {
 // Run creates an isolated parallel or sequential test environment running the
 // given test function with given expectation. When executed via `t.Run()` it
 // checks whether the result is matching the expectation.
+//
+//revive:disable-next-line // internal implementation.
 func run(expect Expect, test func(Test), parallel bool) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()


### PR DESCRIPTION
Adds rules `golangci-lint` consistent rule set for configuring `codacy/revive`. Also updates dependencies.