### PR TITLE
feat: improve handling of repeated parallel test setup (#61)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ endif
 # request targets, while the single target can be used to define the
 # precondition of custom target.
 .PHONY: $(TARGETS) $(addprefix target/,$(TARGETS))
-$(TARGETS):; $(GOBIN)/go-make $(MAKEFLAGS) $(MAKECMDGOALS);
+$(eval $(lastwords $(MAKECMDGOALS)):;@:)
+$(firstword $(MAKECMDGOALS)):
+	$(GOBIN)/go-make $(MAKEFLAGS) $(MAKECMDGOALS);
 $(addprefix target/,$(TARGETS)): target/%:
 	$(GOBIN)/go-make $(MAKEFLAGS) $*;
 

--- a/internal/mock/common_test.go
+++ b/internal/mock/common_test.go
@@ -201,6 +201,11 @@ var (
 		Results:  []*Param{{Type: "string"}},
 		Variadic: false,
 	}, {
+		Name:     "Parallel",
+		Params:   []*Param{},
+		Results:  []*Param{},
+		Variadic: false,
+	}, {
 		Name:     "TempDir",
 		Params:   []*Param{},
 		Results:  []*Param{{Type: "string"}},

--- a/test/caller_test.go
+++ b/test/caller_test.go
@@ -94,7 +94,7 @@ var (
 	}()
 	// CallerTestErrorf provides the file with the line number of the `Errorf`
 	// call in testing.
-	CallerTestErrorf = path.Join(SourceDir, "testing.go:180")
+	CallerTestErrorf = path.Join(SourceDir, "testing.go:204")
 	// CallerGomockErrorf provides the file with the line number of the
 	// `Errorf` call in gomock.
 	CallerGomockErrorf = path.Join(SourceDir, "gomock.go:61")

--- a/test/testing_test.go
+++ b/test/testing_test.go
@@ -280,3 +280,22 @@ func TestTypePanic(t *testing.T) {
 	test.New[TestParam](t, ParamParam{expect: false}).
 		Run(func(t test.Test, param TestParam) {})
 }
+
+func TestParallel(t *testing.T) {
+	t.Parallel()
+	test.New[ParamParam](t, []ParamParam{{expect: false}}).
+		Run(func(t test.Test, param ParamParam) {
+			t.Parallel()
+		})
+}
+
+func TestParallelDenied(t *testing.T) {
+	t.Setenv("TESTING", "true")
+	defer func() {
+		assert.Equal(t, "testing: t.Parallel called after t.Setenv;"+
+			" cannot set environment variables in parallel tests", recover())
+	}()
+
+	test.New[ParamParam](t, []ParamParam{{expect: false}}).
+		Run(func(t test.Test, param ParamParam) {})
+}


### PR DESCRIPTION
This pull request adds a graceful handling for a repeated parallel setup to allow tests to immediately call `t.Parallel` when using `test.Map` etc. It also fixes the `Makefile` to handle multiple targets correctly and improves the test documentation of the `test.Test` interface.