### PR TITLE
feat: support common test methods (#94)

### DIFF
--- a/internal/mock/common_test.go
+++ b/internal/mock/common_test.go
@@ -124,14 +124,12 @@ func methodsMockIFaceFunc(mocktest, test, mock string) []*Method {
 		}, {
 			Name: "err", Type: "error",
 		}},
-		Variadic: false,
 	}, {
 		Name: "CallC",
 		Params: []*Param{{
 			Name: "test", Type: aliasType(test, "Context"),
 		}},
-		Results:  []*Param{},
-		Variadic: false,
+		Results: []*Param{},
 	}}
 }
 
@@ -172,13 +170,25 @@ var (
 		pathTest, pathTesting, pathMock)
 
 	methodsTestTest = []*Method{{
+		Name: "Cleanup",
+		Params: []*Param{
+			{Name: "cleanup", Type: "func()"},
+		},
+		Results: []*Param{},
+	}, {
 		Name:   "Deadline",
 		Params: []*Param{},
 		Results: []*Param{
 			{Name: "deadline", Type: "time.Time"},
 			{Name: "ok", Type: "bool"},
 		},
-		Variadic: false,
+	}, {
+		Name: "Error",
+		Params: []*Param{
+			{Name: "args", Type: "[]any"},
+		},
+		Results:  []*Param{},
+		Variadic: true,
 	}, {
 		Name: "Errorf",
 		Params: []*Param{
@@ -188,10 +198,24 @@ var (
 		Results:  []*Param{},
 		Variadic: true,
 	}, {
-		Name:     "FailNow",
-		Params:   []*Param{},
+		Name:    "Fail",
+		Params:  []*Param{},
+		Results: []*Param{},
+	}, {
+		Name:    "FailNow",
+		Params:  []*Param{},
+		Results: []*Param{},
+	}, {
+		Name:    "Failed",
+		Params:  []*Param{},
+		Results: []*Param{{Type: "bool"}},
+	}, {
+		Name: "Fatal",
+		Params: []*Param{
+			{Name: "args", Type: "[]any"},
+		},
 		Results:  []*Param{},
-		Variadic: false,
+		Variadic: true,
 	}, {
 		Name: "Fatalf",
 		Params: []*Param{
@@ -201,36 +225,76 @@ var (
 		Results:  []*Param{},
 		Variadic: true,
 	}, {
-		Name:     "Helper",
-		Params:   []*Param{},
-		Results:  []*Param{},
-		Variadic: false,
+		Name:    "Helper",
+		Params:  []*Param{},
+		Results: []*Param{},
 	}, {
-		Name:     "Name",
-		Params:   []*Param{},
-		Results:  []*Param{{Type: "string"}},
-		Variadic: false,
-	}, {
-		Name:     "Parallel",
-		Params:   []*Param{},
+		Name: "Log",
+		Params: []*Param{
+			{Name: "args", Type: "[]any"},
+		},
 		Results:  []*Param{},
-		Variadic: false,
+		Variadic: true,
+	}, {
+		Name: "Logf",
+		Params: []*Param{
+			{Name: "format", Type: "string"},
+			{Name: "args", Type: "[]any"},
+		},
+		Results:  []*Param{},
+		Variadic: true,
+	}, {
+		Name:    "Name",
+		Params:  []*Param{},
+		Results: []*Param{{Type: "string"}},
+	}, {
+		Name:    "Parallel",
+		Params:  []*Param{},
+		Results: []*Param{},
 	}, {
 		Name: "Setenv",
 		Params: []*Param{
 			{Name: "key", Type: "string"},
 			{Name: "value", Type: "string"},
 		},
-		Results:  []*Param{},
-		Variadic: false,
+		Results: []*Param{},
 	}, {
-		Name:     "TempDir",
-		Params:   []*Param{},
-		Results:  []*Param{{Type: "string"}},
-		Variadic: false,
+		Name: "Skip",
+		Params: []*Param{
+			{Name: "args", Type: "[]any"},
+		},
+		Results:  []*Param{},
+		Variadic: true,
+	}, {
+		Name:    "SkipNow",
+		Params:  []*Param{},
+		Results: []*Param{},
+	}, {
+		Name: "Skipf",
+		Params: []*Param{
+			{Name: "format", Type: "string"},
+			{Name: "args", Type: "[]any"},
+		},
+		Results:  []*Param{},
+		Variadic: true,
+	}, {
+		Name:    "Skipped",
+		Params:  []*Param{},
+		Results: []*Param{{Type: "bool"}},
+	}, {
+		Name:    "TempDir",
+		Params:  []*Param{},
+		Results: []*Param{{Type: "string"}},
 	}}
 
 	methodsTestReporter = []*Method{{
+		Name: "Error",
+		Params: []*Param{
+			{Name: "args", Type: "[]any"},
+		},
+		Results:  []*Param{},
+		Variadic: true,
+	}, {
 		Name: "Errorf",
 		Params: []*Param{
 			{Name: "format", Type: "string"},
@@ -239,10 +303,20 @@ var (
 		Results:  []*Param{},
 		Variadic: true,
 	}, {
-		Name:     "FailNow",
-		Params:   []*Param{},
+		Name:    "Fail",
+		Params:  []*Param{},
+		Results: []*Param{},
+	}, {
+		Name:    "FailNow",
+		Params:  []*Param{},
+		Results: []*Param{},
+	}, {
+		Name: "Fatal",
+		Params: []*Param{
+			{Name: "args", Type: "[]any"},
+		},
 		Results:  []*Param{},
-		Variadic: false,
+		Variadic: true,
 	}, {
 		Name: "Fatalf",
 		Params: []*Param{
@@ -252,10 +326,9 @@ var (
 		Results:  []*Param{},
 		Variadic: true,
 	}, {
-		Name:     "Panic",
-		Params:   []*Param{{Name: "arg", Type: "any"}},
-		Results:  []*Param{},
-		Variadic: false,
+		Name:    "Panic",
+		Params:  []*Param{{Name: "arg", Type: "any"}},
+		Results: []*Param{},
 	}}
 
 	methodsGoMockTestReporter = []*Method{{

--- a/test/caller_test.go
+++ b/test/caller_test.go
@@ -20,6 +20,13 @@ type Caller struct {
 	path string
 }
 
+// Error is the caller reporter function to capture the callers file and line
+// number of the `Error` call.
+func (c *Caller) Error(_ ...any) {
+	_, path, line, _ := runtime.Caller(1)
+	c.path = path + ":" + strconv.Itoa(line)
+}
+
 // Errorf is the caller reporter function to capture the callers file and line
 // number of the `Errorf` call.
 func (c *Caller) Errorf(_ string, _ ...any) {
@@ -27,9 +34,25 @@ func (c *Caller) Errorf(_ string, _ ...any) {
 	c.path = path + ":" + strconv.Itoa(line)
 }
 
+// Fatal is the caller reporter function to capture the callers file and line
+// number of the `Fatal` call.
+func (c *Caller) Fatal(_ ...any) {
+	_, path, line, _ := runtime.Caller(1)
+	c.path = path + ":" + strconv.Itoa(line)
+	panic("finished") // prevents goexit.
+}
+
 // Fatalf is the caller reporter function to capture the callers file and line
 // number of the `Fatalf` call.
 func (c *Caller) Fatalf(_ string, _ ...any) {
+	_, path, line, _ := runtime.Caller(1)
+	c.path = path + ":" + strconv.Itoa(line)
+	panic("finished") // prevents goexit.
+}
+
+// Fail is the caller reporter function to capture the callers file and line
+// number of the `Fail` call.
+func (c *Caller) Fail() {
 	_, path, line, _ := runtime.Caller(1)
 	c.path = path + ":" + strconv.Itoa(line)
 	panic("finished") // prevents goexit.
@@ -43,6 +66,8 @@ func (c *Caller) FailNow() {
 	panic("finished") // prevents goexit.
 }
 
+// Panic is the caller reporter function to capture the callers file and line
+// number of the `Panic` call.
 func (c *Caller) Panic(_ any) {
 	_, path, line, _ := runtime.Caller(1)
 	c.path = path + ":" + strconv.Itoa(line)
@@ -67,13 +92,25 @@ func getCaller(call func(t test.Reporter)) string {
 }
 
 var (
+	// CallerError provides the file with line number of the `Error` call.
+	CallerError = getCaller(func(t test.Reporter) {
+		t.Error("fail")
+	})
 	// CallerErrorf provides the file with line number of the `Errorf` call.
 	CallerErrorf = getCaller(func(t test.Reporter) {
 		t.Errorf("fail")
 	})
+	// CallerFatal provides the file with line number of the `Fatal` call.
+	CallerFatal = getCaller(func(t test.Reporter) {
+		t.Fatal("fail")
+	})
 	// CallerFatalf provides the file with line number of the `Fatalf` call.
 	CallerFatalf = getCaller(func(t test.Reporter) {
 		t.Fatalf("fail")
+	})
+	// CallerFail provides the file with line number of the `Fail` call.
+	CallerFail = getCaller(func(t test.Reporter) {
+		t.Fail()
 	})
 	// CallerFailNow provides the file with line number of the `FailNow` call.
 	CallerFailNow = getCaller(func(t test.Reporter) {
@@ -92,10 +129,17 @@ var (
 		}
 		return dir
 	}()
-	// CallerTestErrorf provides the file with the line number of the `Errorf`
+	// CallerTestError provides the file with the line number of the `Error`
 	// call in the test context implementation.
-	CallerTestErrorf = path.Join(SourceDir, "context.go:276")
+	CallerTestError = path.Join(SourceDir, "context.go:356")
 	// CallerReporterErrorf provides the file with the line number of the
 	// `Errorf` call in the test reporter/validator implementation.
-	CallerReporterErrorf = path.Join(SourceDir, "gomock.go:61")
+	CallerReporterError = path.Join(SourceDir, "gomock.go:60")
+
+	// CallerTestErrorf provides the file with the line number of the `Errorf`
+	// call in the test context implementation.
+	CallerTestErrorf = path.Join(SourceDir, "context.go:374")
+	// CallerReporterErrorf provides the file with the line number of the
+	// `Errorf` call in the test reporter/validator implementation.
+	CallerReporterErrorf = path.Join(SourceDir, "gomock.go:82")
 )

--- a/test/gomock.go
+++ b/test/gomock.go
@@ -40,6 +40,27 @@ func (v *Validator) EXPECT() *Recorder {
 	return v.recorder
 }
 
+// Error receive expected method call to `Error`.
+func (v *Validator) Error(args ...any) {
+	v.ctrl.T.Helper()
+	v.ctrl.Call(v, "Error", args...)
+}
+
+// Error indicate an expected method call to `Error`.
+func (r *Recorder) Error(args ...any) *gomock.Call {
+	r.validator.ctrl.T.Helper()
+	return r.validator.ctrl.RecordCallWithMethodType(r.validator, "Error",
+		reflect.TypeOf((*Validator)(nil).Error), args...)
+}
+
+// Error creates a validation method call setup for `Error`.
+func Error(args ...any) mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewValidator).EXPECT().
+			Error(args...).Do(mocks.Do(Reporter.Error))
+	}
+}
+
 // Errorf receive expected method call to `Errorf`.
 func (v *Validator) Errorf(format string, args ...any) {
 	v.ctrl.T.Helper()
@@ -62,6 +83,27 @@ func Errorf(format string, args ...any) mock.SetupFunc {
 	}
 }
 
+// Fatal receive expected method call to `Fatal`.
+func (v *Validator) Fatal(args ...any) {
+	v.ctrl.T.Helper()
+	v.ctrl.Call(v, "Fatal", args...)
+}
+
+// Fatal indicate an expected method call to `Fatal`.
+func (r *Recorder) Fatal(args ...any) *gomock.Call {
+	r.validator.ctrl.T.Helper()
+	return r.validator.ctrl.RecordCallWithMethodType(r.validator, "Fatal",
+		reflect.TypeOf((*Validator)(nil).Fatal), args...)
+}
+
+// Fatal creates a validation method call setup for `Fatal`.
+func Fatal(args ...any) mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewValidator).EXPECT().
+			Fatal(args...).Do(mocks.Do(Reporter.Fatal))
+	}
+}
+
 // Fatalf receive expected method call to `Fatalf`.
 func (v *Validator) Fatalf(format string, args ...any) {
 	v.ctrl.T.Helper()
@@ -81,6 +123,27 @@ func Fatalf(format string, args ...any) mock.SetupFunc {
 	return func(mocks *mock.Mocks) any {
 		return mock.Get(mocks, NewValidator).EXPECT().
 			Fatalf(format, args...).Do(mocks.Do(Reporter.Fatalf))
+	}
+}
+
+// Fail receive expected method call to `Fail`.
+func (v *Validator) Fail() {
+	v.ctrl.T.Helper()
+	v.ctrl.Call(v, "Fail")
+}
+
+// Fail indicate an expected method call to `Fail`.
+func (r *Recorder) Fail() *gomock.Call {
+	r.validator.ctrl.T.Helper()
+	return r.validator.ctrl.RecordCallWithMethodType(r.validator, "Fail",
+		reflect.TypeOf((*Validator)(nil).Fail))
+}
+
+// Fail creates a validation method call setup for `Fail`.
+func Fail() mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewValidator).EXPECT().
+			Fail().Do(mocks.Do(Reporter.Fail))
 	}
 }
 

--- a/test/gomock_test.go
+++ b/test/gomock_test.go
@@ -167,16 +167,34 @@ type ReporterParams struct {
 }
 
 var testReporterParams = map[string]ReporterParams{
+	"error called": {
+		mockSetup: test.Error("fail"),
+		call: func(t test.Test) {
+			t.Error("fail")
+		},
+	},
 	"errorf called": {
 		mockSetup: test.Errorf("fail"),
 		call: func(t test.Test) {
 			t.Errorf("fail")
 		},
 	},
+	"fatal called": {
+		mockSetup: test.Fatal("fail"),
+		call: func(t test.Test) {
+			t.Fatal("fail")
+		},
+	},
 	"fatalf called": {
 		mockSetup: test.Fatalf("fail"),
 		call: func(t test.Test) {
 			t.Fatalf("fail")
+		},
+	},
+	"fail called": {
+		mockSetup: test.Fail(),
+		call: func(t test.Test) {
+			t.Fail()
 		},
 	},
 	"failnow called": {
@@ -192,6 +210,21 @@ var testReporterParams = map[string]ReporterParams{
 		},
 	},
 
+	"error undeclared": {
+		failSetup: test.UnexpectedCall(test.NewValidator,
+			"Error", CallerError, "fail"),
+		call: func(t test.Test) {
+			t.Error("fail")
+		},
+	},
+	"error undeclared twice": {
+		failSetup: test.UnexpectedCall(test.NewValidator,
+			"Error", CallerError, "fail"),
+		call: func(t test.Test) {
+			t.Error("fail")
+			t.Error("fail")
+		},
+	},
 	"errorf undeclared": {
 		failSetup: test.UnexpectedCall(test.NewValidator,
 			"Errorf", CallerErrorf, "fail"),
@@ -207,6 +240,22 @@ var testReporterParams = map[string]ReporterParams{
 			t.Errorf("fail")
 		},
 	},
+	"fatal undeclared": {
+		failSetup: test.UnexpectedCall(test.NewValidator,
+			"Fatal", CallerFatal, "fail"),
+		call: func(t test.Test) {
+			t.Fatal("fail")
+		},
+	},
+	"fatal undeclared twice": {
+		failSetup: test.UnexpectedCall(test.NewValidator,
+			"Fatal", CallerFatal, "fail"),
+		call: func(t test.Test) {
+			//revive:disable-next-line:unreachable-code // needed for testing
+			t.Fatal("fail")
+			t.Fatal("fail")
+		},
+	},
 	"fatalf undeclared": {
 		failSetup: test.UnexpectedCall(test.NewValidator,
 			"Fatalf", CallerFatalf, "fail"),
@@ -214,10 +263,28 @@ var testReporterParams = map[string]ReporterParams{
 			t.Fatalf("fail")
 		},
 	},
+	"fatalf undeclared twice": {
+		failSetup: test.UnexpectedCall(test.NewValidator,
+			"Fatalf", CallerFatalf, "fail"),
+		call: func(t test.Test) {
+			//revive:disable-next-line:unreachable-code // needed for testing
+			t.Fatalf("fail")
+			t.Fatalf("fail")
+		},
+	},
 	"failnow undeclared": {
 		failSetup: test.UnexpectedCall(test.NewValidator,
 			"FailNow", CallerFailNow),
 		call: func(t test.Test) {
+			t.FailNow()
+		},
+	},
+	"failnow undeclared twice": {
+		failSetup: test.UnexpectedCall(test.NewValidator,
+			"FailNow", CallerFailNow),
+		call: func(t test.Test) {
+			//revive:disable-next-line:unreachable-code // needed for testing
+			t.FailNow()
 			t.FailNow()
 		},
 	},
@@ -229,9 +296,18 @@ var testReporterParams = map[string]ReporterParams{
 		},
 	},
 
-	// Only Errorf can be consumed more than once, since Fatalf, FailNow, and
-	// panic will stop execution immediately. The second call is effectively
-	// unreachable.
+	// Only `Error`and `Errorf` can be consumed more than once, since `Fatal`,
+	// `Fatalf`, `FailNow`, and panic will stop execution immediately. The
+	// second call is effectively unreachable.
+	"error consumed": {
+		mockSetup: test.Error("fail"),
+		failSetup: test.ConsumedCall(test.NewValidator,
+			"Error", CallerTestError, CallerReporterError, "fail"),
+		call: func(t test.Test) {
+			t.Error("fail")
+			t.Error("fail")
+		},
+	},
 	"errorf consumed": {
 		mockSetup: test.Errorf("fail"),
 		failSetup: test.ConsumedCall(test.NewValidator,
@@ -239,6 +315,14 @@ var testReporterParams = map[string]ReporterParams{
 		call: func(t test.Test) {
 			t.Errorf("fail")
 			t.Errorf("fail")
+		},
+	},
+	"fatal consumed": {
+		mockSetup: test.Fatal("fail"),
+		call: func(t test.Test) {
+			//revive:disable-next-line:unreachable-code // needed for testing
+			t.Fatal("fail")
+			t.Fatal("fail")
 		},
 	},
 	"fatalf consumed": {
@@ -290,6 +374,13 @@ var testReporterParams = map[string]ReporterParams{
 	"fatalf missing": {
 		mockSetup: mock.Chain(test.Errorf("fail"), test.Fatalf("fail")),
 		failSetup: test.MissingCalls(test.Fatalf("fail")),
+		call: func(t test.Test) {
+			t.Errorf("fail")
+		},
+	},
+	"fail missing": {
+		mockSetup: mock.Chain(test.Errorf("fail"), test.Fail()),
+		failSetup: test.MissingCalls(test.Fail()),
 		call: func(t test.Test) {
 			t.Errorf("fail")
 		},


### PR DESCRIPTION
This pull request adds support for more of common test methods provided by the testing package, making the `test.Test` interface mostly compatible with the `testing.TB` interface.